### PR TITLE
Add missing public/index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Http\Request;
+
+define('LARAVEL_START', microtime(true));
+
+require __DIR__.'/../vendor/autoload.php';
+
+$app = require_once __DIR__.'/../bootstrap/app.php';
+
+$kernel = $app->make(Kernel::class);
+
+$response = $kernel->handle(
+    $request = Request::capture()
+)->send();
+
+$kernel->terminate($request, $response);


### PR DESCRIPTION
## Summary
- create `public/index.php` so the Laravel app can run

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe00e5b7483309ebfe97bd53fe172